### PR TITLE
repo: strictly enforce LF EOL for all script files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.* text eol=lf
+*.html text eol=lf
+*.js* text eol=lf
+*.vue text eol=lf


### PR DESCRIPTION
This pull request resolves the following issue:
(#4) repo: CLRF line endings imposed on JS files by git

By adding `eol=lf` to `.gitattributes`, it forces git to not attempt to normalise the line endings in the repository to the default line ending style of that OS.

As such, JS tests would run on a newly cloned working copy on OSes that do no use LF line endings.