### PR TITLE
app: add support for vue-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "vue": "^2.1.0"
+    "vue": "^2.1.0",
+    "vue-router": "^2.1.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,13 @@
 <template>
   <div id="app">
     <img src="./assets/logo.png">
-    <hello></hello>
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
-import Hello from './components/Hello';
-
 export default {
   name: 'app',
-  components: {
-    Hello,
-  },
 };
 </script>
 

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,0 +1,8 @@
+import Hello from '../components/Hello';
+
+export default [
+  {
+    path: '/',
+    component: Hello,
+  },
+];

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,21 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
+import VueRouter from 'vue-router';
+
 import App from './App';
+import routes from './config/routes';
+
+Vue.use(VueRouter);
+
+const router = new VueRouter({
+  routes,
+});
 
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
   template: '<App/>',
   components: { App },
+  router,
 });


### PR DESCRIPTION
Given that the site has multiple pages, every page
needs to be directly accessible from a URL.

Thus, vue-router enables the app to associate
views/components to a specific URL.